### PR TITLE
Avoid 'fork me' banner jump when displaying the menu on mobile

### DIFF
--- a/themes/privatebin-bootstrap/templates/base.html
+++ b/themes/privatebin-bootstrap/templates/base.html
@@ -57,11 +57,11 @@
 				<a class="reloadlink navbar-brand" href="{{ SITEURL }}/">
 					<img alt="{{ SITENAME }}" src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/img/icon.svg" width="38" />
 				</a>
-			</div>
-			<div id="navbar" class="navbar-collapse collapse">
 {% if GITHUB_RIBBON_URL is defined %}
 				<a class="github-fork-ribbon" href="{{ GITHUB_RIBBON_URL }}" title="Fork me on GitHub">Fork me on GitHub</a>
 {% endif %}
+			</div>
+			<div id="navbar" class="navbar-collapse collapse">
 {% if TRYITOUT_BUTTON_URL is defined %}
 				<ul class="nav navbar-nav">
 					<li>


### PR DESCRIPTION
As the menu scrolls down on mobile, the 'fork me' bannier is under the topbar. But at the end of the menu opening, it jumps to the top of the page.

This commit makes sure the 'fork me' button remains in the menu, like this :
![capture d ecran de 2017-06-29 23-33-42](https://user-images.githubusercontent.com/7191841/27711406-739e3fb8-5d23-11e7-8636-729606b3cb5f.png)
