### PR TITLE
Fix unresponsive logo

### DIFF
--- a/content/pages/home.md
+++ b/content/pages/home.md
@@ -5,7 +5,7 @@ Sortorder: 1
 URL:
 save_as: index.html
 
-# [<img alt="PrivateBin" src="https://cdn.rawgit.com/PrivateBin/assets/master/images/minified/logo.svg" width="500" />](https://privatebin.info/)
+# [<img alt="PrivateBin" src="https://cdn.rawgit.com/PrivateBin/assets/master/images/minified/logo.svg" class="img-responsive" />](https://privatebin.info/)
 [![Build Status](https://travis-ci.org/PrivateBin/PrivateBin.svg?branch=master)](https://travis-ci.org/PrivateBin/PrivateBin) [![Build Status](https://scrutinizer-ci.com/g/PrivateBin/PrivateBin/badges/build.png?b=master)](https://scrutinizer-ci.com/g/PrivateBin/PrivateBin/build-status/master)  
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/094500f62abf4c9aa0c8a8a4520e4789)](https://www.codacy.com/app/PrivateBin/PrivateBin)
 [![Code Climate](https://codeclimate.com/github/PrivateBin/PrivateBin/badges/gpa.svg)](https://codeclimate.com/github/PrivateBin/PrivateBin)


### PR DESCRIPTION
The logo on the main page doesn't fit and breaks the page layout on small screens:

![screen_shot_2017-06-30_at_01 14 05](https://user-images.githubusercontent.com/26872252/27714518-a7a1170a-5d31-11e7-88b3-01f112ce7764.png)

This commit makes the logo responsive using the dedicated `.img-responsive` bootstrap 3 class.

![screen_shot_2017-06-30_at_01 16 30 1](https://user-images.githubusercontent.com/26872252/27714563-ebcbaf30-5d31-11e7-8ed1-4d2a8a643d10.png)

