### PR TITLE
allow CORS pre-flight check to pass

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -167,6 +167,14 @@ server {
 
     # proxy to demo site container
     location / {
+        if ($request_method = OPTIONS) {
+            add_header Content-Length 0;
+            add_header Content-Type text/plain;
+            add_header Access-Control-Allow-Origin *;
+            add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE";
+            add_header Access-Control-Allow-Headers "X-Requested-With, Content-Type";
+            return 200;
+        }
         proxy_pass  http://demo;
         proxy_cache privatebin;
         proxy_http_version 1.1;


### PR DESCRIPTION
This let's the demo instance get used as storage by web-based third party clients, for example:
- https://github.com/PrivateBin/PrivateBin/issues/889
- https://github.com/PrivateBin/PrivateBin/issues/2