### PR TITLE
using the 204 No Content HTTP status

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -168,12 +168,10 @@ server {
     # proxy to demo site container
     location / {
         if ($request_method = OPTIONS) {
-            add_header Content-Length 0;
-            add_header Content-Type text/plain;
             add_header Access-Control-Allow-Origin *;
             add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE";
             add_header Access-Control-Allow-Headers "X-Requested-With, Content-Type";
-            return 200;
+            return 204;
         }
         proxy_pass  http://demo;
         proxy_cache privatebin;


### PR DESCRIPTION
makes it unnecessary to send a content length header, fixes HTTP/2 requests