### PR TITLE
bootstrap CSS v5 support

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -108,7 +108,7 @@ server {
     add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload";
 
     # Other security headers
-    add_header Content-Security-Policy "default-src 'none'; font-src 'self'; img-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'";
+    add_header Content-Security-Policy "default-src 'none'; font-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'";
     add_header Permissions-Policy "interest-cohort=()";
     add_header Referrer-Policy no-referrer;
     add_header X-Content-Type-Options nosniff;


### PR DESCRIPTION
bootstrap CSS v5.1.2 (used in directory v0.8.0) uses data:-URLs for some of it's widgets