### PR TITLE
correct installation links

### DIFF
--- a/content/pages/home.md
+++ b/content/pages/home.md
@@ -103,7 +103,7 @@ file](https://github.com/PrivateBin/PrivateBin/wiki/Configuration):
 
 * [FAQ](https://github.com/PrivateBin/PrivateBin/wiki/FAQ)
 
-* [Installation guide](https://github.com/PrivateBin/PrivateBin/blob/master/INSTALL.md#installation)
+* [Installation guide](https://github.com/PrivateBin/PrivateBin/blob/master/doc/Installation.md)
 
 * [Configuration guide](https://github.com/PrivateBin/PrivateBin/wiki/Configuration)
 

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -34,7 +34,7 @@ MENUITEMS = (('FAQ', 'https://github.com/PrivateBin/PrivateBin/wiki/FAQ'),
              ('Find instance', '/directory/'))
 
 # Blogroll
-LINKS = (('Installation guide', 'https://github.com/PrivateBin/PrivateBin/blob/master/INSTALL.md#installation'),
+LINKS = (('Installation guide', 'https://github.com/PrivateBin/PrivateBin/blob/master/doc/Installation.md'),
          ('Configuration guide', 'https://github.com/PrivateBin/PrivateBin/wiki/Configuration'),
          ('Template guide', 'https://github.com/PrivateBin/PrivateBin/wiki/Templates'),
          ('Upgrading from ZeroBin 0.19 Alpha', 'https://github.com/PrivateBin/PrivateBin/wiki/Upgrading-from-ZeroBin-0.19-Alpha'),


### PR DESCRIPTION
Getting a 404 when you want to know how to install Privatebin is not very encouraging.
This should be fixed.