### PR TITLE
Updating TLS Mozilla modern config

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -16,11 +16,10 @@ ssl_session_cache shared:SSL:50m;
 ssl_session_timeout 30m;
 ssl_session_tickets off;
 
-# Mozilla modern configuration + TLS 1.3
-ssl_protocols TLSv1.2 TLSv1.3;
-ssl_ciphers 'TLS-CHACHA20-POLY1305-SHA256:TLS-AES-256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256';
-ssl_ecdh_curve X448:secp521r1:secp384r1:prime256v1;
-ssl_prefer_server_ciphers on;
+# Mozilla intermediate configuration, generated 2023-12-07
+# https://ssl-config.mozilla.org/#server=nginx&version=1.24.0&config=modern&openssl=1.1.1k&guideline=5.7
+ssl_protocols TLSv1.3;
+ssl_prefer_server_ciphers off;
 
 # OCSP Stapling ---
 # fetch OCSP records from URL in ssl_certificate and cache them


### PR DESCRIPTION
Well… time has passed and modern seems to be TLS 1.e only.

Mozilla says:
> Supports Firefox 63, Android 10.0, Chrome 70, Edge 75, Java 11, OpenSSL 1.1.1, Opera 57, and Safari 12.1 

Given we use WebCrypto (okay not on the info page, but well…), we have a strict compatibility level anyway. To be fair, I see, however, WebCrypto is supported on some older devices, actually: https://caniuse.com/cryptography

So I don't know…