### PR TITLE
Also add CVE ID to website

### DIFF
--- a/content/2025-10-28-Vulnerability.md
+++ b/content/2025-10-28-Vulnerability.md
@@ -1,4 +1,4 @@
-Title: Vulnerability Report: Missing HTML sanitisation of attached filename in file size hint enabling persistent XSS, defacement, open redirect attacks etc.
+Title: Vulnerability Report: Missing HTML sanitisation of attached filename in file size hint enabling persistent XSS, defacement, open redirect attacks etc. (CVE-2025-62796)
 Date: 2025-10-28 17:00
 Category: Reports
 Tags: PrivateBin, Security


### PR DESCRIPTION
I have added the now published CVE (and GitHub's) ID of the vulnerability to the release at https://github.com/PrivateBin/PrivateBin/releases/tag/2.0.2 and this PR here is for the website, too.

OI guess this helps a lot for SEO etc. to find the corresponding information.

BTW @elrido the news does not seem to be published on https://privatebin.info/category/news.html yet.