### PR TITLE
docs: update with new Pelican domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository hosts the files used to generate the PrivateBin website,
 hosted at https://privatebin.info.
 
-The files are generated with [Pelican](https://blog.getpelican.com/).
+The files are generated with [Pelican](https://getpelican.com/).
 
 ## Setup
 


### PR DESCRIPTION
They have apparently dropped the `blog.` suffix, which makes sense. :wink: