### PR TITLE
harden github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,7 @@ updates:
           - "1.35.*"
           - "1.37.*"
           - "1.39.*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -4,12 +4,16 @@ on:
   push:
     tags: '*'
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
- restrict all default permissions
- content: read is not necessary for public repos
- security-events: write is needed for CodeQL uploads of SARIF reports
- persist-credentials: false prevents any github token to remain configured in the checked out repo (not necessary when not intending to push from the action)
- enable github actions updates in dependabot